### PR TITLE
Enable using proxy and kubeconfig to connect to remote clusters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ Remote Velero is a fork of Velero. Velero lets you:
 
 Velero consists of:
 
-* A server that runs on your cluster
-* A command-line client that runs locally
+* A server that runs on your cluster.
+* A command-line client that runs locally.
 
 Remote Velero is the same as above with the addition of
 
-* The ability to back up from a remote cluster (called the source cluster)
-* The ability to restore to a remote cluster (called the destination cluster)
+* The ability to back up from a remote cluster (called the source cluster).
+* The ability to restore to a remote cluster (called the destination cluster).
 
-## How to Use Remote Velero (OPTION 1: One Velero to Two Remote Clusters)
+## How to Use Remote Velero (OPTION 1: One Velero using Two Different Remote Clusters)
 
 Here are instructions for setting up one Velero installation on a local service cluster.
 Service account credentials enable Velero to connect to two different remote clusters:
@@ -33,7 +33,7 @@ one for the source (backup) cluster, and the other for the destination (restore)
       ```
 
     * The binary will be generated in a subdirectory of `<Remote Velero project root>/_output/bin/`
-    * A binary with version 0.0.1 of Remote Velero has been included in [remote-velero/binaries](remote-velero/binaries)
+    * Remote Velero binary releases are [available for download](https://github.com/codegold79/remote-velero/releases)
 
 1. Provide remote cluster credentials
 
@@ -47,14 +47,17 @@ one for the source (backup) cluster, and the other for the destination (restore)
 
     ```bash
     kubectl delete namespace velero; kubectl delete crd -l component=velero
-    ````
+    ```
 
-    * Adjust and apply secrets, one each for your two remote clusters (one for source/backup and another for destination/restore)
+    * Modify and apply secrets, one each for your two remote clusters (one for source/backup and another for destination/restore)
 
         * The secret for the remote source cluster must be named `srccluster`.
         * The secret for the remote destination cluster must be named `destcluster`.
         * Both secrets must be in the namespace that Velero was installed in.
-        * The data in each secret must contain the host URL associated with the `host` key, and the service account token for the `sa-token` key.
+        * Provide cluster credentials in one of two ways:
+          1. The data in each secret must contain the host URL associated with the `host` key, and the service account token for the `sa-token` key.
+          2. Or, provide the contents of the remote cluster's `kubeconfig` file in the `kubeconfig` key.
+        * In the secret, you can optionally provide an HTTPS proxy url to use under the `https_proxy` key.
         * See an example secret manifest for a remote source cluster in [remote-velero/service-acct-creds/src-cluster-cred-example.yaml](remote-velero/service-acct-creds/src-cluster-cred-example.yaml).
 
         ```yaml
@@ -65,8 +68,10 @@ one for the source (backup) cluster, and the other for the destination (restore)
         namespace: <namespace where Velero is installed>
         type: Opaque
         data:
-        host: <base64 encoded host URL>
-        sa-token: <base64 encoded service account token here>
+          host: <base64 encoded host URL>
+          sa-token: <base64 encoded service account token here>
+          kubeconfig: <base64 encoded kubeconfig file contents here>
+          https_proxy: <base64 encoded https proxy URL here>
         ```
 
 1. Install Remote Velero
@@ -76,7 +81,7 @@ one for the source (backup) cluster, and the other for the destination (restore)
     * Use client binary to install Remote Velero, pointing to a Remote Velero image.
 
     ```bash
-    export VERSION=0.0.2 export IMAGE=projects.registry.vmware.com/tanzu_migrator/remote-velero
+    export VERSION=<version number> export IMAGE=projects.registry.vmware.com/tanzu_migrator/remote-velero
     vel install \
     --features=EnableAPIGroupVersions \
     --provider aws \
@@ -89,22 +94,22 @@ one for the source (backup) cluster, and the other for the destination (restore)
     --image $IMAGE:$VERSION
     ```
 
-    * **Note:** You can use your own image if you'd like. Create an image with `make container`.
+    * **Note:** Instead of downloading the Velero client binary, you can build your own image with `make container`.
     * To ensure the server is now pointing to the correct remote clusters, look at the velero deployment logs and look for a message similar to the following:
 
     ```bash
     level=info msg="Server is using source cluster at https://example.servicemesh.biz:6443." 
-    level=info msg="Server is using namespace velero." logSource="pkg/cmd/server/server.go:408"
+    level=info msg="Server is using namespace velero."
     level=info msg="Server is using destination cluster at https://example.us-east-2.elb.amazonaws.com:443."
     ```
 
-1. Run backup of a namespace on a remote source cluster
+1. Run backup of a namespace on a remote source cluster.
 
     ```bash
     velero backup create backup-1 --include-namespaces example
     ```
 
-1. Run restore of a namespace on a remote destination cluster
+1. Run restore of a namespace on a remote destination cluster.
 
     ```bash
     velero restore create restore-1 --from-backup backup-1
@@ -115,18 +120,18 @@ one for the source (backup) cluster, and the other for the destination (restore)
 Here are instructions for setting up two namespaces, each with a Velero installation. Each Velero installation connects to a single
 remote cluster. You can have as many namespaces and Veleros that a single cluster can hold.
 
-Instructions are very similar to Option 1, one velero for two remote that build details have been omitted here.
+Instructions are very similar to Option 1, one velero for two remote clusters. Some build details have been omitted here.
 
-1. Get latest Remote Velero client version from [remote-velero/binaries](remote-velero/binaries)
+1. Get latest Remote Velero client version from [available binary releases](https://github.com/codegold79/remote-velero/releases).
 
-1. Provide remote cluster credentials before installing Velero in the same namespace
+1. Provide remote cluster credentials before installing Velero in the same namespace.
 
-    * Create a namespace that Velero will be installed to, e.g. "src-velero"
+    * Create a namespace that Velero will be installed to, e.g. "src-velero".
 
       ```bash
       kubectl create namespace src-velero
       ```
-    * Create additional namespace(s) that other Veleros will be installed to, e.g. "dest-velero"
+    * Create additional namespace(s) that other Veleros will be installed to, e.g. "dest-velero".
 
       ```bash
       kubectl create namespace dest-velero
@@ -137,7 +142,10 @@ Instructions are very similar to Option 1, one velero for two remote that build 
     **Note: Each namespace has a single secret named "remotecluster".**
 
     * The secret added to each namespace must be named `remotecluster`.
-    * The data in each secret must contain the host URL associated with the `host` key, and the service account token for the `sa-token` key.
+    * Provide cluster credentials for each remote cluster in one of two ways:
+        1. The data in each secret must contain the host URL associated with the `host` key, and the service account token for the `sa-token` key.
+        2. Or, provide the contents of the remote cluster's `kubeconfig` file in the `kubeconfig` key.
+    * In the secret, you can optionally provide an HTTPS proxy url to use under the `https_proxy` key.
     * See an example secret manifest for a remote source cluster in [remote-velero/service-acct-creds/src-cluster-cred-example.yaml](remote-velero/service-acct-creds/remote-cluster-cred-example.yaml).
 
         ```yaml
@@ -150,6 +158,8 @@ Instructions are very similar to Option 1, one velero for two remote that build 
         data:
         host: <base64 encoded host URL>
         sa-token: <base64 encoded service account token here>
+        kubeconfig: <base64 encoded kubeconfig file contents here>
+        https_proxy: <base64 encoded https proxy URL here>
         ```
 
 1. Install Remote Velero in Every Namespace
@@ -159,7 +169,7 @@ Instructions are very similar to Option 1, one velero for two remote that build 
     * Install Remote Velero, pointing to a Remote Velero server image. Be sure to include the `--namespace src-velero` flag with the `velero install` client command.
 
     ```bash
-    export VERSION=0.0.2 export IMAGE=projects.registry.vmware.com/tanzu_migrator/remote-velero
+    export VERSION=<version> export IMAGE=projects.registry.vmware.com/tanzu_migrator/remote-velero
     vel install \
     --features=EnableAPIGroupVersions \
     --provider aws \
@@ -173,7 +183,6 @@ Instructions are very similar to Option 1, one velero for two remote that build 
     --namespace src-velero
     ```
 
-    * **Note:** You can use your own image if you'd like. Create an image with `make container`.
     * To ensure the server is now pointing to the correct remote clusters, look at the velero deployment logs and look for a message similar to the following:
 
     ```bash
@@ -182,13 +191,13 @@ Instructions are very similar to Option 1, one velero for two remote that build 
     level=info msg="Server is using destination cluster at https://example.us-east-2.elb.amazonaws.com:443."
     ```
 
-1. Run backup of a namespace on a remote source cluster
+1. Run backup of a namespace on a remote source cluster.
 
     ```bash
     velero backup create backup-1 --include-namespaces example --namespace src-velero
     ```
 
-1. Run restore of a namespace on a remote destination cluster
+1. Run restore of a namespace on a remote destination cluster.
 
     ```bash
     velero restore create restore-1 --from-backup backup-1 --namespace dest-velero

--- a/examples/minio/00-minio-deployment.yaml
+++ b/examples/minio/00-minio-deployment.yaml
@@ -44,7 +44,7 @@ spec:
         emptyDir: {}
       containers:
       - name: minio
-        image: minio/minio:latest
+        image: harbor-repo.vmware.com/dockerhub-proxy-cache/minio/minio:latest 
         imagePullPolicy: IfNotPresent
         args:
         - server
@@ -102,7 +102,7 @@ spec:
         emptyDir: {}
       containers:
       - name: mc
-        image: minio/mc:latest
+        image: harbor-repo.vmware.com/dockerhub-proxy-cache/minio/mc:latest
         imagePullPolicy: IfNotPresent
         command:
         - /bin/sh

--- a/pkg/cmd/cli/install/install.go
+++ b/pkg/cmd/cli/install/install.go
@@ -71,6 +71,8 @@ type InstallOptions struct {
 	CACertFile                        string
 	Features                          string
 	DefaultVolumesToRestic            bool
+	HttpsProxy                        string
+	HttpProxy                         string
 }
 
 // BindFlags adds command line values to the options struct.
@@ -187,6 +189,8 @@ func (o *InstallOptions) AsVeleroOptions() (*install.VeleroOptions, error) {
 		CACertData:                        caCertData,
 		Features:                          strings.Split(o.Features, ","),
 		DefaultVolumesToRestic:            o.DefaultVolumesToRestic,
+		HttpsProxy:                        o.HttpsProxy,
+		HttpProxy:                         o.HttpProxy,
 	}, nil
 }
 
@@ -247,6 +251,15 @@ This is useful as a starting point for more customized installations.
 // Run executes a command in the context of the provided arguments.
 func (o *InstallOptions) Run(c *cobra.Command, f client.Factory) error {
 	var resources *unstructured.UnstructuredList
+
+	if f.HttpProxy() != "" {
+		o.HttpProxy = f.HttpProxy()
+	}
+
+	if f.HttpsProxy() != "" {
+		o.HttpsProxy = f.HttpsProxy()
+	}
+
 	if o.CRDsOnly {
 		resources = install.AllCRDs()
 	} else {

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -253,6 +253,9 @@ type server struct {
 	config                              serverConfig
 	mgr                                 manager.Manager
 	credentialFileStore                 credentials.FileStore
+
+	httpsProxy string
+	httpProxy  string
 }
 
 func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*server, error) {
@@ -387,6 +390,8 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 		config:                              config,
 		mgr:                                 mgr,
 		credentialFileStore:                 credentialFileStore,
+		httpsProxy:                          f.HttpsProxy(),
+		httpProxy:                           f.HttpProxy(),
 	}
 
 	return s, nil
@@ -404,6 +409,19 @@ func (s *server) run() error {
 	} else {
 		s.logger.Infof("Server is using current kubectx for source.")
 	}
+
+	if s.httpsProxy != "" {
+		s.logger.Infof("Server is using https_proxy at %s.", s.httpsProxy)
+	} else {
+		s.logger.Infof("Server is using no https_proxy.")
+	}
+
+	// TODO: http_proxy is accepted via flag, but not yet implemented.
+	// if s.httpProxy != "" {
+	// 	s.logger.Infof("Server is using http_proxy at %s.", s.httpProxy)
+	// } else {
+	// 	s.logger.Infof("Server is using no http_proxy.")
+	// }
 
 	s.logger.Infof("Server is using namespace %s.", s.namespace)
 

--- a/pkg/install/deployment.go
+++ b/pkg/install/deployment.go
@@ -41,6 +41,8 @@ type podTemplateConfig struct {
 	plugins                           []string
 	features                          []string
 	defaultVolumesToRestic            bool
+	httpsProxy                        string
+	httpProxy                         string
 }
 
 func WithImage(image string) podTemplateOption {
@@ -114,6 +116,18 @@ func WithDefaultVolumesToRestic() podTemplateOption {
 	}
 }
 
+func WithHttpsProxy(proxy string) podTemplateOption {
+	return func(c *podTemplateConfig) {
+		c.httpsProxy = proxy
+	}
+}
+
+func WithHttpProxy(proxy string) podTemplateOption {
+	return func(c *podTemplateConfig) {
+		c.httpProxy = proxy
+	}
+}
+
 func Deployment(namespace string, opts ...podTemplateOption) *appsv1.Deployment {
 	// TODO: Add support for server args
 	c := &podTemplateConfig{
@@ -138,6 +152,14 @@ func Deployment(namespace string, opts ...podTemplateOption) *appsv1.Deployment 
 
 	if c.defaultVolumesToRestic {
 		args = append(args, "--default-volumes-to-restic=true")
+	}
+
+	if c.httpsProxy != "" {
+		args = append(args, "--httpsproxy="+c.httpsProxy)
+	}
+
+	if c.httpProxy != "" {
+		args = append(args, "--httpproxy="+c.httpProxy)
 	}
 
 	containerLabels := Labels()

--- a/pkg/install/resources.go
+++ b/pkg/install/resources.go
@@ -228,6 +228,8 @@ type VeleroOptions struct {
 	CACertData                        []byte
 	Features                          []string
 	DefaultVolumesToRestic            bool
+	HttpsProxy                        string
+	HttpProxy                         string
 }
 
 func AllCRDs() *unstructured.UnstructuredList {
@@ -297,6 +299,14 @@ func AllResources(o *VeleroOptions) (*unstructured.UnstructuredList, error) {
 
 	if o.DefaultVolumesToRestic {
 		deployOpts = append(deployOpts, WithDefaultVolumesToRestic())
+	}
+
+	if o.HttpsProxy != "" {
+		deployOpts = append(deployOpts, WithHttpsProxy(o.HttpsProxy))
+	}
+
+	if o.HttpProxy != "" {
+		deployOpts = append(deployOpts, WithHttpProxy(o.HttpProxy))
 	}
 
 	deploy := Deployment(o.Namespace, deployOpts...)

--- a/remote-velero/changelogs/CHANGELOG-0.0.3.md
+++ b/remote-velero/changelogs/CHANGELOG-0.0.3.md
@@ -1,0 +1,5 @@
+# Changes
+
+- Enable passing in of httpsProxy via secret.
+- Enable passing in of httpsProxy and httpProxy via Velero install flags. Proxy flags override secrets. HttpProxy is not yet being used.
+- Enable passing in of a kubeconfig that makes use of TLS via secret. Requires TLS certificate data.

--- a/remote-velero/service-acct-creds/dest-cluster-cred-example.yaml
+++ b/remote-velero/service-acct-creds/dest-cluster-cred-example.yaml
@@ -7,3 +7,5 @@ type: Opaque
 data:
   host: <base64 encoded host URL>
   sa-token: <base64 encoded service account token here>
+  kubeconfig: <base64 encoded kubeconfig here>
+  https_proxy: http://<address>:<port>

--- a/remote-velero/service-acct-creds/remote-cluster-cred-example.yaml
+++ b/remote-velero/service-acct-creds/remote-cluster-cred-example.yaml
@@ -7,3 +7,5 @@ type: Opaque
 data:
   host: <base64 encoded host URL>
   sa-token: <base64 encoded service account token here>
+  kubeconfig: <base64 encoded kubeconfig here>
+  https_proxy: <base64 encoded https_proxy with the http://<address>:<port> format>

--- a/remote-velero/service-acct-creds/src-cluster-cred-example.yaml
+++ b/remote-velero/service-acct-creds/src-cluster-cred-example.yaml
@@ -7,3 +7,5 @@ type: Opaque
 data:
   host: <base64 encoded host URL>
   sa-token: <base64 encoded service account token here>
+  kubeconfig: <base64 encoded kubeconfig here>
+  https_proxy: http://<address>:<port>


### PR DESCRIPTION
With this change, one can pass a kubeconfig via a secret instead of a service account token and host. The kubeconfig will be preferred over the SA token + host combination. The kubeconfig must use TLS. The SA token + host combination will always have TLS disabled.

Another change is the ability to specify an https_proxy URL in the secret. The proxy can also optionally be passed in via a flag during Velero installation and the flag will override the proxy URL in the secret.